### PR TITLE
removed str_random() usage since its no longer available

### DIFF
--- a/src/idoc/IDocGenerator.php
+++ b/src/idoc/IDocGenerator.php
@@ -289,7 +289,7 @@ class IDocGenerator
                 return $faker->boolean();
             },
             'string' => function () use ($faker) {
-                return str_random();
+                return $faker->asciify('************');
             },
             'array' => function () {
                 return '[]';


### PR DESCRIPTION
Fixes the following error:

```
Call to undefined function OVAC\IDoc\str_random()

  at /.../IDocGenerator.php:292
    288|             'boolean' => function () use ($faker) {
    289|                 return $faker->boolean();
    290|             },
    291|             'string' => function () use ($faker) {
  > 292|                 return str_random();
    293|             },
    294|             'array' => function () {
    295|                 return '[]';
    296|             },
```