### PR TITLE
bug-fix for lumen frame work:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 composer.lock
 .php_cs.cache
 /vendor/
+/.idea
 /public
 .couscous/
 .phpintel/

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ This will create an `idoc.php` file in your `config` folder.
 ### Lumen
 - Register the service provider in your `bootstrap/app.php`:
 ```php
-$app->register(\OVAC\IDoc\IDocServiceProvider::class);
+$app->bind('path.public', function ($app) { return $app->basePath('../your-public-path'); });
+$app->register(\OVAC\IDoc\IDocLumenServiceProvider::class);
 ```
 - Copy the config file from `vendor/ovac/idoc/config/idoc.php` to your project as `config/idoc.php`. Then add to your `bootstrap/app.php`:
 ```php

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,9 @@
         "league/fractal": "^0.17.0"
     },
     "autoload": {
+        "files": [
+            "helpers/helpers.php"
+        ],
         "psr-4": {
             "OVAC\\IDoc\\": "src/idoc"
         }

--- a/helpers/helpers.php
+++ b/helpers/helpers.php
@@ -1,0 +1,13 @@
+<?php
+if (! function_exists('public_path')) {
+    /**
+     * Get the path to the public folder.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    function public_path($path = '')
+    {
+        return app()->make('path.public').($path ? DIRECTORY_SEPARATOR.ltrim($path, DIRECTORY_SEPARATOR) : $path);
+    }
+}

--- a/resources/routes/lumen.php
+++ b/resources/routes/lumen.php
@@ -1,0 +1,9 @@
+<?php
+
+/** @var Laravel\Lumen\Routing\Router $router */
+
+//This is the route for the documentation info page.
+$router->get('info', [function () { return view('idoc::partials.info'); }, 'as' => 'info']);
+
+//This is the route for the root documentation view page.
+$router->get('', [function () { return view('idoc::documentation'); }, 'as' => 'root']);

--- a/src/idoc/IDocLumenServiceProvider.php
+++ b/src/idoc/IDocLumenServiceProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace OVAC\IDoc;
+
+class IDocLumenServiceProvider extends IDocServiceProvider
+{
+    public function boot()
+    {
+        $this->registerRoutes();
+        $this->registerPublishing();
+
+        $this->loadTranslationsFrom(__DIR__ . '/../../resources/lang', 'idoc');
+        $this->loadViewsFrom(__DIR__ . '/../../resources/views/', 'idoc');
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                IDocGeneratorCommand::class,
+            ]);
+        }
+    }
+
+    protected function registerRoutes()
+    {
+        app()->router->group($this->routeConfiguration(), function ($router) {
+            require __DIR__ . '/../../resources/routes/lumen.php';
+        });
+    }
+
+    protected function routeConfiguration()
+    {
+        return [
+            'domain' => config('idoc.domain'),
+            'prefix' => config('idoc.path'),
+            'middleware' => config('idoc.middleware', []),
+            'as' => 'idoc',
+        ];
+    }
+}

--- a/src/idoc/IDocServiceProvider.php
+++ b/src/idoc/IDocServiceProvider.php
@@ -34,7 +34,7 @@ class IDocServiceProvider extends ServiceProvider
      *
      * @return array
      */
-    private function registerRoutes()
+    protected function registerRoutes()
     {
         Route::group($this->routeConfiguration(), function () {
             $this->loadRoutesFrom(__DIR__ . '/../../resources/routes/idoc.php', 'idoc');
@@ -46,7 +46,7 @@ class IDocServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    private function registerPublishing()
+    protected function registerPublishing()
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
@@ -68,7 +68,7 @@ class IDocServiceProvider extends ServiceProvider
      *
      * @return array
      */
-    private function routeConfiguration()
+    protected function routeConfiguration()
     {
         return [
             'domain' => config('idoc.domain', null),


### PR DESCRIPTION
**pull request purpose:**
bare repo is not working with any lumen version
error: `Call to undefined method Illuminate\Routing\Router::middlewareGroup()`
reason: middle group is not supported in lumen, lumen has it's own router

- add laravel default public_path helper because it's not present in lumen `usage IDocGeneratorCommand line 74`
- improve readme.md to define public path if needed
- add new routes for lumen because it's totaly diffrent
- extends service provider for lumen