### PR TITLE
Feat: PHP8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,9 @@
     "require-dev": {
         "orchestra/testbench": "3.5.* || 3.6.* || 3.7.* || 5.1.* || ^6.0 || ^9.0 || ^10.0",
         "phpunit/phpunit": "^6.0.0 || ^7.4.0 || ^9.0 || ^10.5 || ^11.5.3",
-        "dingo/api": "2.0.0-alpha1",
         "mockery/mockery": "^1.2.0",
-        "league/fractal": "^0.17.0 || ^0.20"
+        "league/fractal": "^0.17.0 || ^0.20",
+        "api-ecosystem-for-laravel/dingo-api": "^4.7"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
Switch dev packages to make all packages work on PHP8.
Regardless of this PR being accepted, would there be an chance of a new release being cut? While dev-master works, it would be nice to have an clean version for Laravel 12.