### PR TITLE
Allow for customisation of external fonts location

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,18 @@ A short and simple permissive license with conditions only requiring preservatio
 - `output`
 This package can automatically generate an Open-API 3.0 specification file for your routes, along with the documentation. This is the file path where the generated documentation will be written to. Default: **public/docs** 
 
- - `hide_download_button`
+- `resources`
+Locations of external resources, that can be customised for self-hosting if required.
+```php
+'resources' => [
+        'fonts' => '//fonts.googleapis.com/css?family=Roboto:400,700',
+        'redoc_standalone_js' => 'https://cdn.jsdelivr.net/npm/redoc@2.5.1/bundles/redoc.standalone.js',
+        'swagger_css' => 'https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css',
+        'swagger_ui_js' => 'https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js',
+],
+```
+
+- `hide_download_button`
 This section is where you can configure if you want a download button visible on the documentation.
 
 - `router`

--- a/config/idoc.php
+++ b/config/idoc.php
@@ -201,6 +201,7 @@ return [
     'output' => '',
 
     'resources' => [
+        'fonts' => '//fonts.googleapis.com/css?family=Roboto:400,700',
         'redoc_standalone_js' => 'https://cdn.jsdelivr.net/npm/redoc@2.5.1/bundles/redoc.standalone.js',
         'swagger_css' => 'https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css',
         'swagger_ui_js' => 'https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js',

--- a/resources/views/documentation.blade.php
+++ b/resources/views/documentation.blade.php
@@ -60,6 +60,7 @@
   - idoc.output                : Directory containing openapi.json (public path).
   - idoc.external_description  : Optional route for external description content.
   - idoc.hide_download_button  : Redoc's download button visibility.
+  - idoc.resources.fonts       : Fonts location.
   - idoc.resources.redoc_standalone_js: Redoc standalone JS bundle location.
   - idoc.resources.swagger_css : Swagger UI CSS file location.
   - idoc.resources.swagger_ui_js: Swagger UI JS bundle location.
@@ -88,8 +89,8 @@
 
   BUNDLES
   -------
-  - Redoc OSS:  https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js
-  - Swagger UI: https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/
+  - Redoc OSS:  {{ config('idoc.resources.redoc_standalone_js') }}
+  - Swagger UI: {{ config('idoc.resoures.swagger_ui_js') }}
   - Markdown + sanitize: marked + DOMPurify
   - Syntax highlight: highlight.js (auto‑switched for dark/light)
 
@@ -125,7 +126,7 @@
          ========================= -->
     <style>
       /* System font for speed + Verdana for legibility */
-      @import url(//fonts.googleapis.com/css?family=Roboto:400,700);
+      @import url({{ config('idoc.resources.fonts') }});
       body { margin: 0; padding: 0; font-family: Verdana, Geneva, sans-serif; }
 
       /* Optional logo in Redoc's sidebar (only if you inject an <img>) */


### PR DESCRIPTION
Allow for customisation of external fonts. This is a follow up to https://github.com/ovac/idoc/pull/54 and also updates the README to document the new config options.