### PR TITLE
Fix typo in commented HTML for bundle location config entry

### DIFF
--- a/resources/views/documentation.blade.php
+++ b/resources/views/documentation.blade.php
@@ -90,7 +90,7 @@
   BUNDLES
   -------
   - Redoc OSS:  {{ config('idoc.resources.redoc_standalone_js') }}
-  - Swagger UI: {{ config('idoc.resoures.swagger_ui_js') }}
+  - Swagger UI: {{ config('idoc.resources.swagger_ui_js') }}
   - Markdown + sanitize: marked + DOMPurify
   - Syntax highlight: highlight.js (auto‑switched for dark/light)
 


### PR DESCRIPTION
Fix typo in bundle location config entry.

This is "only" in commented HTML, so doesn't affect the rendering of the page, but better to fix in any case.